### PR TITLE
Add pr-log to maintain a CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0 (November 18, 2014)
+
+Initial release

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "check-coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100",
         "report-coverage-html": "istanbul report html",
         "coveralls": "cat ./build/coverage/lcov.info | coveralls",
-        "test": "npm run lint && npm run unit-test --coverage && npm run check-coverage"
+        "test": "npm run lint && npm run unit-test --coverage && npm run check-coverage",
+        "changelog": "pr-log"
     },
     "dependencies": {
         "mongodb": "^1.4.19",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "eslint-plugin-mocha": "0.2.2",
         "istanbul": "0.3.2",
         "coveralls": "2.11.2",
-        "proxyquire": "1.0.1"
+        "proxyquire": "1.0.1",
+        "pr-log": "1.0.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
This adds pr-log as a tool for maintaining our changelog.
Before every release you have to run `npm run changelog <version-number>` where `<version-number>` should be the version of the release you want to publish.

Fixes #17.